### PR TITLE
Updates for how pointer return types are handled

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_wldap32.rb
@@ -83,17 +83,17 @@ class Def_windows_wldap32
     ], 'ldap_next_attributeA', "cdecl")
 
     dll.add_function('ldap_count_values', 'ULONG',[
-        ['PLPVOID', 'vals', 'in'],
+        ['LPVOID', 'vals', 'in'],
     ], 'ldap_count_values', "cdecl")
 
-    dll.add_function('ldap_get_values', 'PLPVOID',[
+    dll.add_function('ldap_get_values', 'LPVOID',[
         ['LPVOID', 'ld', 'in'],
         ['LPVOID', 'entry', 'in'],
         ['PCHAR', 'attr', 'in']
     ], 'ldap_get_values', "cdecl")
 
     dll.add_function('ldap_value_free', 'ULONG',[
-        ['PLPVOID', 'vals', 'in'],
+        ['LPVOID', 'vals', 'in'],
     ], 'ldap_value_free', "cdecl")
 
     dll.add_function('ldap_memfree', 'VOID',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -228,7 +228,7 @@ class Library
         # it's not a pointer (LPVOID is a pointer but is not backed by railgun memory, ala PBLOB)
         buffer = [0].pack(native)
         case param_desc[0]
-          when 'LPVOID', 'PULONG_PTR', 'ULONG_PTR'
+          when 'LPVOID', 'ULONG_PTR'
             num     = param_to_number(args[param_idx])
             buffer += [num].pack(native)
           when 'DWORD'
@@ -273,8 +273,8 @@ class Library
     [packet, layouts]
   end
 
-  def build_response(packet, function, layouts, arch)
-    case arch
+  def build_response(packet, function, layouts, client)
+    case client.native_arch
     when ARCH_X64
       native = 'Q<'
     when ARCH_X86
@@ -301,7 +301,7 @@ class Library
     # process return value
     case function.return_type
       when 'LPVOID', 'ULONG_PTR'
-        if arch == ARCH_X64
+        if client.native_arch == ARCH_X64
           return_hash['return'] = rec_return_value
         else
           return_hash['return'] = rec_return_value & 0xffffffff
@@ -317,9 +317,19 @@ class Library
       when 'VOID'
         return_hash['return'] = nil
       when 'PCHAR'
-        return_hash['return'] = rec_return_value == 0 ? nil : read_string(rec_return_value)
+        return_hash['return'] = rec_return_value == 0 ? nil : client.railgun.util.read_string(rec_return_value)
+        return_hash['&return'] = rec_return_value
       when 'PWCHAR'
-        return_hash['return'] = rec_return_value == 0 ? nil : read_wstring(rec_return_value)
+        return_hash['return'] = rec_return_value == 0 ? nil : client.railgun.util.read_wstring(rec_return_value)
+        return_hash['&return'] = rec_return_value
+      when 'PULONG_PTR'
+        if client.native_arch == ARCH_X64
+          return_hash['return'] = rec_return_value == 0 ? nil : client.railgun.util.memread(rec_return_value, 8).unpack1('Q')
+          return_hash['&return'] = rec_return_value
+        else
+          return_hash['return'] = rec_return_value == 0 ? nil : client.railgun.util.memread(rec_return_value, 4).unpack1('V')
+          return_hash['&return'] = rec_return_value
+        end
       else
         raise "unexpected return type: #{function.return_type}"
     end
@@ -379,7 +389,7 @@ class Library
 
     response = client.send_request(request)
 
-    build_response(response, function, layouts, client.native_arch)
+    build_response(response, function, layouts, client)
   end
 
   # perform type conversions as necessary to reduce the datatypes to their primitives

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
@@ -90,7 +90,7 @@ class MultiCaller
       lib_name, function, args = f
       library = @parent.get_library(lib_name)
       function = library.functions[function] unless function.instance_of? LibraryFunction
-      function_results << library.build_response(call_results.shift, function, call_layouts.shift, @client.native_arch)
+      function_results << library.build_response(call_results.shift, function, call_layouts.shift, @client)
     end
 
     function_results


### PR DESCRIPTION
Updates how railgun handles pointer return types to fix `ldap_get_values`, `ldap_count_values` and `ldap_value_free`.

Treats those functions as just dealing with a pointer since we don't have a full `PCHAR *` data type. From the docs of those functions, it should be a pointer to a null-terminated array of pointers to null-terminated array of characters. This ensure railgun properly handles the pointer so the value can be freed.

Also implements the suggestion from https://github.com/rapid7/metasploit-framework/pull/17562#discussion_r1103247033.